### PR TITLE
Regex for named charRefs between a start tag and data does not consume semicolon.

### DIFF
--- a/lib/tiny-lexer.js
+++ b/lib/tiny-lexer.js
@@ -50,7 +50,7 @@ const DOCTYPE_START = '<![Dd][Oo][Cc][Tt][Yy][Pp][Ee]'
 // of a known named reference. 
 
 const CHARREF_CONTD = '&(?:copysr|centerdot|divideontimes|[gl]t(?:quest|dot|cir|cc)|[gl]trPar|gtr(?:dot|less|eqqless|eqless|approx|arr|sim)|ltr(?:i|if|ie|mes)|ltlarr|lthree|notin(?:dot|E|v[abc])?|notni(?:v[abc])?|parallel|times(?:bar|d|b));'
-const CHARREF_LEGACY = '&(?:[AEIOUYaeiouy]?acute|[AEIOUaeiou](?:grave|circ|uml)|y?uml|[ANOano]tilde|[Aa]ring|[Oo]slash|[Cc]?cedil|brvbar|curren|divide|frac(?:12|14|34)|iquest|middot|plusmn|(?:AE|ae|sz)lig|[lr]aquo|iexcl|micro|pound|THORN|thorn|times|COPY|copy|cent|macr|nbsp|ord[fm]|para|QUOT|quot|sect|sup[123]|AMP|amp|ETH|eth|REG|reg|deg|not|shy|yen|GT|gt|LT|lt)'
+const CHARREF_LEGACY = '&(?:[AEIOUYaeiouy]?acute|[AEIOUaeiou](?:grave|circ|uml)|y?uml|[ANOano]tilde|[Aa]ring|[Oo]slash|[Cc]?cedil|brvbar|curren|divide|frac(?:12|14|34)|iquest|middot|plusmn|(?:AE|ae|sz)lig|[lr]aquo|iexcl|micro|pound|THORN|thorn|times|COPY|copy|cent|macr|nbsp|ord[fm]|para|QUOT|quot|sect|sup[123]|AMP|amp|ETH|eth|REG|reg|deg|not|shy|yen|GT|gt|LT|lt);?'
 
 const T = tokenTypes
 const grammar = 


### PR DESCRIPTION
npm RunKit: https://runkit.com/embed/228enpu7mmud

``` JavaScript
const tinyHtmlLexer = require("tiny-html-lexer")

const html = `<span style="font-weight:bold">&quot;this is bold and in quotes&quot;</span>`;
const stream = tinyHtmlLexer.chunks(html);

for (const [type, chunk] of stream) {
    console.log({type, chunk});
}
```

The **expected** behavior is that `{chunk: "&quot;", type: "charRef-named"}` and then `{chunk: "this is bold and in quotes", type: "data"}` are printed to the console.

The **current** behavior is that `{chunk: "&quot", type: "charRef-named"}` and then `{chunk: ";this is bold and in quotes", type: "data"}` are printed to the console. 

I think this can be remedied by changing https://github.com/alwinb/tiny-html-lexer/blob/9863e1498179fcf68d2eda1fc839e84a26bfcac1/lib/tiny-lexer.js#L53 to 

``` JavaScript
const CHARREF_LEGACY = '&(?:[AEIOUYaeiouy]?acute|[AEIOUaeiou](?:grave|circ|uml)|y?uml|[ANOano]tilde|[Aa]ring|[Oo]slash|[Cc]?cedil|brvbar|curren|divide|frac(?:12|14|34)|iquest|middot|plusmn|(?:AE|ae|sz)lig|[lr]aquo|iexcl|micro|pound|THORN|thorn|times|COPY|copy|cent|macr|nbsp|ord[fm]|para|QUOT|quot|sect|sup[123]|AMP|amp|ETH|eth|REG|reg|deg|not|shy|yen|GT|gt|LT|lt);?'
```

(i.e. adding `;?` to the end of the grammar - https://runkit.com/embed/c0mk998cbo30).

The breaking change was introduced by the 0.8.4 release (https://github.com/alwinb/tiny-html-lexer/commit/9863e1498179fcf68d2eda1fc839e84a26bfcac1)